### PR TITLE
.p.*callable type error and foreign, py keyword arg fixes

### DIFF
--- a/p.q
+++ b/p.q
@@ -1,4 +1,3 @@
-/ can we make default callable for python callables, returning embedPy, explicit resolution in cases where object is callable and has attributes?
 .p:(`:./p 2:`lib,1)`
 \d .p
 e:{x[0]y;}runs

--- a/p.q
+++ b/p.q
@@ -1,3 +1,4 @@
+if[system["s"]|0>system"p";'"slaves or multithreaded input not currently supported"];
 .p:(`:./p 2:`lib,1)`
 \d .p
 e:{x[0]y;}runs

--- a/p.q
+++ b/p.q
@@ -1,3 +1,4 @@
+/ can we make default callable for python callables, returning embedPy, explicit resolution in cases where object is callable and has attributes?
 .p:(`:./p 2:`lib,1)`
 \d .p
 e:{x[0]y;}runs
@@ -27,9 +28,9 @@ import:ce wfunc pyimport
 .p.set:{[f;x;y]f[x]unwrap y;}.p.set
 .p.key:{wrap pykey$[i.isf x;x;i.isw x;x($);'`type]}
 .p.value:{wrap pyvalue$[i.isf x;x;i.isw x;x($);'`type]}
-.p.callable:{$[i.isw x;x(*);'type]}
-.p.pycallable:{$[i.isw x;x(>);'type]}
-.p.qcallable:{$[i.isw x;x(<);'type]}
+.p.callable:{$[i.isw x;x(*);i.isf x;wrap[x](*);'`type]}
+.p.pycallable:{$[i.isw x;x(>);i.isf x;wrap[x](>);'`type]}
+.p.qcallable:{$[i.isw x;x(<);i.isf x;wrap[x](<);'`type]}
 / is foreign, wrapped, callable
 i.isf:112=type@ 
 i.isw:{$[105=type x;wf~$[104=type u:first get x;first get u;0b];0b]}
@@ -53,17 +54,19 @@ q2pargs:{
  if[x~enlist(::);:(();()!())]; / zero args
  hd:(k:i.gpykwargs x)0; 
  al:neg[hd]_(a:i.gpyargs x)0;
- if[any 1_prev[u]and not u:`..pykw~'first each neg[hd]_x;'"keywords last"]; / check arg order
+ if[any 1_prev[u]and not u:i.isarg[i.kw]each neg[hd]_x;'"keywords last"]; / check arg order
  cn:{$[()~x;x;11<>type x;'`type;x~distinct x;x;'`dupnames]};
- :(unwrap each x[where not[al]&not u],a 1;cn[named[;1],key k 1]!(unwrap each named:(x,(::))where u)[;2],value k 1)
+ :(unwrap each x[where not[al]&not u],a 1;cn[named[;1],key k 1]!(unwrap each named:get'[(x,(::))where u])[;2],value k 1)
  }
-if[not`pykw      in key`.q;.p.pykw:     (`..pykw;;);.q.pykw:.p.pykw]           / identify keyword args with `name pykw value
-if[not`pyarglist in key`.q;.p.pyarglist:(`..pyas;) ;.q.pyarglist:.p.pyarglist] / identify pos arg list (*args in python)
-if[not`pykwargs  in key`.q;.p.pykwargs: (`..pyks;) ;.q.pykwargs:.p.pykwargs]   / identify keyword dict (**kwargs in python)
+/ TODO tidy, maybe arglist and kwargs don't need the lambdas?
+if[not`pykw      in key`.q;pykw:     {x[y;z]}i.kw:(`..pykw;;;);.q.pykw:pykw]           / identify keyword args with `name pykw value
+if[not`pyarglist in key`.q;pyarglist:{x y}i.al:(`..pyas;;)    ;.q.pyarglist:pyarglist] / identify pos arg list (*args in python)
+if[not`pykwargs  in key`.q;pykwargs: {x y}i.ad:(`..pyks;;)    ;.q.pykwargs:pykwargs]   / identify keyword dict (**kwargs in python)
 i.gpykwargs:{dd:(0#`)!();
- $[not any u:`..pyks~'first each x;(0;dd);not last u;'"pykwargs last";
-  1<sum u;'"only one pykwargs allowed";(1;dd,x[where u;1]0)]}
-i.gpyargs:{$[not any u:`..pyas~'first each x;(u;());1<sum u;'"only one pyargs allowed";(u;(),x[where u;1]0)]}
+ $[not any u:i.isarg[i.ad]each x;(0;dd);not last u;'"pykwargs last";
+  1<sum u;'"only one pykwargs allowed";(1;dd,get[x where[u]0]1)]}
+i.gpyargs:{$[not any u:i.isarg[i.al]each x;(u;());1<sum u;'"only one pyargs allowed";(u;(),get[x where[u]0]1)]}
+i.isarg:{$[104=type y;x~first get y;0b]} / y is python argument identifier x
 
 / Help & Print
 gethelp:{[h;x]$[i.isf x;h x;i.isw x;h x($);i.isc x;h 2{last get x}/first get x;"no help available"]}
@@ -85,5 +88,5 @@ closure:.p.get[`qclosure;*] / implement as: closure[{[state;dummy] ...;(newState
 
 / Generators
 p)import itertools
-gl:.p.eval["lambda f,n:(f(x)for x in(itertools.count()if n==None else range(n)))"][>]
-generator:{[f;i;n]gl[closure[f;i]($);n]}
+i.gl:.p.eval["lambda f,n:(f(x)for x in(itertools.count()if n==None else range(n)))"][>]
+generator:{[f;i;n]i.gl[closure[f;i]($);n]}

--- a/p.q
+++ b/p.q
@@ -57,7 +57,6 @@ q2pargs:{
  cn:{$[()~x;x;11<>type x;'`type;x~distinct x;x;'`dupnames]};
  :(unwrap each x[where not[al]&not u],a 1;cn[named[;1],key k 1]!(unwrap each named:get'[(x,(::))where u])[;2],value k 1)
  }
-/ TODO tidy, maybe arglist and kwargs don't need the lambdas?
 if[not`pykw      in key`.q;pykw:     {x[y;z]}i.kw:(`..pykw;;;);.q.pykw:pykw]           / identify keyword args with `name pykw value
 if[not`pyarglist in key`.q;pyarglist:{x y}i.al:(`..pyas;;)    ;.q.pyarglist:pyarglist] / identify pos arg list (*args in python)
 if[not`pykwargs  in key`.q;pykwargs: {x y}i.ad:(`..pyks;;)    ;.q.pykwargs:pykwargs]   / identify keyword dict (**kwargs in python)


### PR DESCRIPTION
.p.qcallable,.p.pycallable,.p.callable can take foreigns and throw type error if not wrapped or foreign
pykwargs,pykw,pykwargs list can now be used with '
e.g.
p)def foo(a=1,b=2,c=3,d=4):return (a,b,c,d,a*b*c*d)
q)foo:.p.qcallable .p.get`foo
q)foo'[1 2 3 4;5 6 7 8;1;`d pykw 2] / was failing as last arg is 3 element list

now last arg is projection and ' can be used